### PR TITLE
Convert EmmyLua function type output to LuaCATS notation

### DIFF
--- a/sphinx_lua_ls/objtree.py
+++ b/sphinx_lua_ls/objtree.py
@@ -950,10 +950,6 @@ class EmmyLuaParser(Parser):
         "LuaLatest": "5.4",
     }
 
-    @staticmethod
-    def _norm_type(typ: str) -> str:
-        return (typ or "unknown").replace("->", ":")
-
     def parse(self, json, path: str | pathlib.Path):
         self.path = pathlib.Path(path).expanduser().resolve()
 
@@ -1022,7 +1018,7 @@ class EmmyLuaParser(Parser):
         self.add(data["name"], res)
 
     def _parse_enum(self, data):
-        res = Enum(type=self._norm_type(data["typ"] or "unknown"))
+        res = Enum(type=data["typ"] or "unknown")
         self._set_common(res, data)
         self._set_locs(res, data)
         self._parse_generics(res, data.get("generics", []))
@@ -1031,7 +1027,7 @@ class EmmyLuaParser(Parser):
         self.add(data["name"], res)
 
     def _parse_alias(self, data):
-        res = Alias(type=self._norm_type(data["typ"]))
+        res = Alias(type=data["typ"] or "unknown")
         self._set_common(res, data)
         self._set_locs(res, data)
         self._parse_generics(res, data.get("generics", []))
@@ -1055,7 +1051,7 @@ class EmmyLuaParser(Parser):
         self.add(data["name"], res)
 
     def _parse_global_field(self, data):
-        res = Data(type=self._norm_type(data["typ"]))
+        res = Data(type=data["typ"])
         self._set_common(res, data)
         self._set_loc(res, data)
         res.lit = data["literal"]
@@ -1076,11 +1072,11 @@ class EmmyLuaParser(Parser):
         self._parse_generics(res, data.get("generics", []))
         for param in data["params"]:
             res.params.append(
-                Param(name=param["name"], type=self._norm_type(param["typ"]), docstring=param["desc"])
+                Param(name=param["name"], type=param["typ"], docstring=param["desc"])
             )
         for param in data["returns"]:
             res.returns.append(
-                Param(name=param["name"], type=self._norm_type(param["typ"]), docstring=param["desc"])
+                Param(name=param["name"], type=param["typ"], docstring=param["desc"])
             )
         res.overloads = data["overloads"]
         res.implicit_self = data["is_meth"]
@@ -1090,7 +1086,7 @@ class EmmyLuaParser(Parser):
         self.add_child(parent, data["name"], res)
 
     def _parse_field(self, parent: Object, data):
-        res = Data(type=self._norm_type(data["typ"]))
+        res = Data(type=data["typ"])
         self._set_common(res, data)
         self._set_loc(res, data)
         res.lit = data["literal"]

--- a/sphinx_lua_ls/utils.py
+++ b/sphinx_lua_ls/utils.py
@@ -229,7 +229,7 @@ _TYPE_PARSE_RE = re.compile(
     # Ident not followed by an open brace, semicolon, etc.
     # Example: `module.Type`.
     # Doesn't match: `name?: ...`, `name( ...`, etc.
-    (?P<ident>[\w-]+(?:\.[\w-]+)*)
+    (?P<ident>\w[\w-]*(?:\.\w[\w-]*)*)
     \s*(?P<ident_qm>\??)\s*
     (?![:(\w.?-])
     |
@@ -242,13 +242,19 @@ _TYPE_PARSE_RE = re.compile(
     |
     # Name component, only matches when `ident` and `type` didn't match.
     # Example: `string: ...`.
-    (?P<name>[\w.-]+)
+    (?P<name>\w[\w.-]*)
     |
     # Punctuation that we separate with spaces.
     (?P<punct>[=:,|&])
     |
+    # Braces.
+    (?P<brace>[()[\]{}])
+    |
+    # Functional arrow (will be replaced with semicolon).
+    (?P<arrow>->)
+    |
     # Punctuation that we copy as-is, without adding spaces.
-    (?P<other_punct>[-!#$%()*+/;<>?@[\]^_{}~]+)
+    (?P<other_punct>[-!#$%*+/\\;<>?@[\]^_{}~]+)
     |
     # Anything else is copied as-is.
     (?P<other>.)
@@ -300,6 +306,11 @@ def type_to_nodes(typ: str, inliner) -> list[nodes.Node]:
                 res.append(addnodes.desc_sig_space())
             res.append(addnodes.desc_sig_punctuation(text, text))
             res.append(addnodes.desc_sig_space())
+        elif text := match.group("brace"):
+            res.append(addnodes.desc_sig_punctuation(text, text))
+        elif text := match.group("arrow"):
+            res.append(addnodes.desc_sig_punctuation(":", ":"))
+            res.append(addnodes.desc_sig_space())
         elif text := match.group("other_punct"):
             res.append(addnodes.desc_sig_punctuation(text, text))
         elif text := match.group("other"):
@@ -343,6 +354,10 @@ def normalize_type(typ: str) -> str:
                 res += " "
             res += text
             res += " "
+        elif text := match.group("brace"):
+            res += text
+        elif text := match.group("arrow"):
+            res += ": "
         elif text := match.group("other_punct"):
             res += text
         elif text := match.group("other"):

--- a/test/roots/test-doc/src/directives.rst
+++ b/test/roots/test-doc/src/directives.rst
@@ -63,7 +63,11 @@ Directives
 
       Description
 
-   .. lua:function:: function_complex_types(T: integer, b: table<T, target_module.T>, c: fun(T: T, ...): (T: T, ...)) -> a: table<string, string>, ...: fun(a: integer, ...): (a: integer, ...)
+   .. lua:function:: function_complex_types(T: integer, b: table<T, target_module.T>, c: fun(T: T, ...) -> (T: T, ...)) -> a: table<string, string>, ...: fun(a: integer, ...) -> (a: integer, ...)
+
+      Description
+
+   .. lua:function:: function_complex_types(T: integer, b: table<T, target_module.T>, c: fun(T: T, ...): (T: T, ...)): a: table<string, string>, ...: fun(a: integer, ...): (a: integer, ...)
 
       Description
 

--- a/test/test_regression/autodoc-emmylua-object_types.html
+++ b/test/test_regression/autodoc-emmylua-object_types.html
@@ -796,15 +796,12 @@
      )
     </span>
    </span>
-   <code class="xref lua lua-_auto docutils literal notranslate">
-    <span class="pre">
-     -
-    </span>
-   </code>
    <span class="p">
     <span class="pre">
-     &gt;
+     :
     </span>
+   </span>
+   <span class="w">
    </span>
    <span class="p">
     <span class="pre">
@@ -951,15 +948,12 @@
      )
     </span>
    </span>
-   <code class="xref lua lua-_auto docutils literal notranslate">
-    <span class="pre">
-     -
-    </span>
-   </code>
    <span class="p">
     <span class="pre">
-     &gt;
+     :
     </span>
+   </span>
+   <span class="w">
    </span>
    <span class="p">
     <span class="pre">

--- a/test/test_regression/doc-directives.html
+++ b/test/test_regression/doc-directives.html
@@ -761,7 +761,12 @@
    </a>
    <span class="p">
     <span class="pre">
-     []
+     [
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     ]
     </span>
    </span>
    <a class="headerlink" href="#lua-function_generics_return" title="Link to this definition">
@@ -842,7 +847,12 @@
    </a>
    <span class="p">
     <span class="pre">
-     []
+     [
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     ]
     </span>
    </span>
    <a class="headerlink" href="#lua-function_generics_args_and_return" title="Link to this definition">
@@ -1246,6 +1256,406 @@
     </span>
    </span>
    <a class="headerlink" href="#lua-function_complex_types" title="Link to this definition">
+    ¶
+   </a>
+   <br/>
+  </dt>
+  <dd>
+   <p>
+    Description
+   </p>
+  </dd>
+ </dl>
+ <dl class="lua function">
+  <dt class="sig sig-object lua" id="lua-0">
+   <span class="sig-name descname">
+    <span class="pre">
+     function_complex_types
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     (
+    </span>
+   </span>
+   <br/>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     T
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <code class="xref lua lua-_auto docutils literal notranslate">
+    <span class="pre">
+     integer
+    </span>
+   </code>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <br/>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     b
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <code class="xref lua lua-_auto docutils literal notranslate">
+    <span class="pre">
+     table
+    </span>
+   </code>
+   <span class="p">
+    <span class="pre">
+     &lt;
+    </span>
+   </span>
+   <a class="reference internal" href="#lua-T" title="T">
+    <code class="xref lua lua-_auto docutils literal notranslate">
+     <span class="pre">
+      T
+     </span>
+    </code>
+   </a>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <a class="reference internal" href="#lua-target_module.T" title="target_module.T">
+    <code class="xref lua lua-_auto docutils literal notranslate">
+     <span class="pre">
+      target_module.T
+     </span>
+    </code>
+   </a>
+   <span class="p">
+    <span class="pre">
+     &gt;
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <br/>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     c
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="k">
+    <span class="pre">
+     fun
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     (
+    </span>
+   </span>
+   <span class="n">
+    <span class="pre">
+     T
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <a class="reference internal" href="#lua-T" title="T">
+    <code class="xref lua lua-_auto docutils literal notranslate">
+     <span class="pre">
+      T
+     </span>
+    </code>
+   </a>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     ...
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     )
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="p">
+    <span class="pre">
+     (
+    </span>
+   </span>
+   <span class="n">
+    <span class="pre">
+     T
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <a class="reference internal" href="#lua-T" title="T">
+    <code class="xref lua lua-_auto docutils literal notranslate">
+     <span class="pre">
+      T
+     </span>
+    </code>
+   </a>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     ...
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     )
+    </span>
+   </span>
+   <br/>
+   <span class="p">
+    <span class="pre">
+     )
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="p">
+    <span class="pre">
+     (
+    </span>
+   </span>
+   <br/>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     a
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <code class="xref lua lua-_auto docutils literal notranslate">
+    <span class="pre">
+     table
+    </span>
+   </code>
+   <span class="p">
+    <span class="pre">
+     &lt;
+    </span>
+   </span>
+   <code class="xref lua lua-_auto docutils literal notranslate">
+    <span class="pre">
+     string
+    </span>
+   </code>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <code class="xref lua lua-_auto docutils literal notranslate">
+    <span class="pre">
+     string
+    </span>
+   </code>
+   <span class="p">
+    <span class="pre">
+     &gt;
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <br/>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     ...
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="k">
+    <span class="pre">
+     fun
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     (
+    </span>
+   </span>
+   <span class="n">
+    <span class="pre">
+     a
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <code class="xref lua lua-_auto docutils literal notranslate">
+    <span class="pre">
+     integer
+    </span>
+   </code>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     ...
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     )
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="p">
+    <span class="pre">
+     (
+    </span>
+   </span>
+   <span class="n">
+    <span class="pre">
+     a
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     :
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <code class="xref lua lua-_auto docutils literal notranslate">
+    <span class="pre">
+     integer
+    </span>
+   </code>
+   <span class="p">
+    <span class="pre">
+     ,
+    </span>
+   </span>
+   <span class="w">
+   </span>
+   <span class="n">
+    <span class="pre">
+     ...
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     )
+    </span>
+   </span>
+   <br/>
+   <span class="p">
+    <span class="pre">
+     )
+    </span>
+   </span>
+   <a class="headerlink" href="#lua-0" title="Link to this definition">
     ¶
    </a>
    <br/>
@@ -2187,7 +2597,12 @@
    </a>
    <span class="p">
     <span class="pre">
-     []
+     [
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     ]
     </span>
    </span>
    <a class="headerlink" href="#lua-class_generic_with_base" title="Link to this definition">
@@ -2618,7 +3033,12 @@
    </a>
    <span class="p">
     <span class="pre">
-     []
+     [
+    </span>
+   </span>
+   <span class="p">
+    <span class="pre">
+     ]
     </span>
    </span>
    <a class="headerlink" href="#lua-alias_generic" title="Link to this definition">


### PR DESCRIPTION
This is sort of a strawman drive-by PR.  I noticed that the `->` function return type notation from EmmyLua is passed through verbatim and renders awkwardly with the ReadTheDocs theme.  I figured it was better to just use standard LuaCATS notation anyway instead of going down the Sphinx Markdown/HTML/CSS rabbit hole.  Feel free to suggest a different approach if you prefer arrow notation.

Before:
<img width="610" height="112" alt="before" src="https://github.com/user-attachments/assets/c8d3c404-234f-4557-9f74-aa3f1697f18d" />

After:
<img width="571" height="108" alt="after" src="https://github.com/user-attachments/assets/51ff8fc7-48f0-40d5-ad3d-35e055d9e031" />
