### PR TITLE
Avoid treating a `-` by itself as an identifier

### DIFF
--- a/sphinx_lua_ls/utils.py
+++ b/sphinx_lua_ls/utils.py
@@ -229,7 +229,7 @@ _TYPE_PARSE_RE = re.compile(
     # Ident not followed by an open brace, semicolon, etc.
     # Example: `module.Type`.
     # Doesn't match: `name?: ...`, `name( ...`, etc.
-    (?P<ident>[\w-]+(?:\.[\w-]+)*)
+    (?P<ident>\w[\w-]*(?:\.\w[\w-]*)*)
     \s*(?P<ident_qm>\??)\s*
     (?![:(\w.?-])
     |
@@ -242,7 +242,7 @@ _TYPE_PARSE_RE = re.compile(
     |
     # Name component, only matches when `ident` and `type` didn't match.
     # Example: `string: ...`.
-    (?P<name>[\w.-]+)
+    (?P<name>[\w.][\w.-]*)
     |
     # Punctuation that we separate with spaces.
     (?P<punct>[=:,|&])


### PR DESCRIPTION
This is a minimal fix which resolves the issue for me.  It avoids treating `-` as an identifier.

<img width="582" height="111" alt="image" src="https://github.com/user-attachments/assets/0bd0194b-876c-4439-9fdd-417c0d10cf31" />
