### PR TITLE
Migrate dev harness to uv / ruff / pyright / tox / prek / poe

### DIFF
--- a/.coveragerc.toml
+++ b/.coveragerc.toml
@@ -1,0 +1,22 @@
+[run]
+relative_files = true
+
+[report]
+include = ["sphinx_lua_ls/**/*.py"]
+omit = [
+    "sphinx_lua_ls/_version.py",
+    "test/**/*.py",
+]
+exclude_also = [
+    "def __repr__",
+    "def __rich_repr__",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if (|_t\\.|typing\\.)TYPE_CHECKING:",
+    "@(abc\\.)?abstractmethod",
+    "except ImportError:",
+    "assert False",
+]
+
+[html]
+title = "Sphinx-LuaLs Coverage Report"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,20 +10,30 @@ updates:
           - "beautifulsoup4"
           - "furo"
           - "myst-parser"
+          - "PyGithub"
           - "pyright"
-          - "pytest_image_diff"
           - "pytest-cov"
           - "pytest-regressions"
           - "pytest"
-          - "reportlab"
+          - "requests"
           - "sphinx_design"
-          - "svglib"
+          - "sphinx-autobuild"
+          - "sphinx"
           - "sybil"
+          - "tox"
+          - "tox-uv"
       style:
         patterns:
-          - "black"
-          - "isort"
-          - "pre-commit"
+          - "prek"
+          - "ruff"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Test package
+name: test
 on:
   push:
     branches:
@@ -8,7 +8,10 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
+  # Downloads LuaLs and EmmyLua binaries for all OSes and uploads them as an
+  # artifact so that the test job can re-use them without re-downloading.
   prepare:
     name: Download LuaLs
     runs-on: ubuntu-latest
@@ -44,6 +47,10 @@ jobs:
           path: ~/lua_ls_release
           include-hidden-files: true
           retention-days: 3
+
+  # Runs main tests for the package.
+  #
+  # Runs on all events except when closing a pull request.
   test:
     name: Test package
     needs:
@@ -81,25 +88,28 @@ jobs:
           path: ~/lua_ls_release
       - name: Test package
         if: ${{ matrix.type == 'test' }}
-        run: poe ci
+        run: |
+          poe ci
         env:
           LUA_LS_CACHE_PATH: ~/lua_ls_release/${{ matrix.os }}
       # Lint
       - name: Check code style
         if: ${{ matrix.type == 'code style' }}
-        run: poe lint --color always
-  publish_to_pypi:
-    name: Publish package to PyPi
-    needs:
-      - test
+        run: |
+          poe lint --color always
+
+  # Builds python packages.
+  #
+  # Only runs on tag pushes.
+  build:
+    name: Build package
     if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/sphinx-lua-ls
-    permissions:
-      contents: write
-      id-token: write
+    outputs:
+      link: ${{ steps.metadata.outputs.link }}
+      is-pre-release: ${{ steps.changelog.outputs.is-pre-release }}
+      is-unreleased: ${{ steps.changelog.outputs.is-unreleased }}
+      changelog-text: ${{ steps.changelog.outputs.text }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -110,23 +120,46 @@ jobs:
         run: |
           ref="${{ github.ref }}";
           version=${ref#refs/tags/v};
-          link="https://pypi.org/p/sphinx-lua-ls/${version}";
+          link="https://pypi.org/p/sphinx-lua-ls/${version}/";
           echo "link=${link}" >> $GITHUB_OUTPUT
       - name: Parse Changelog
         id: changelog
         uses: taminomara/cl-keeper@v1
         with:
           version: ${{ github.ref }}
-      - name: Set up python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.12
-      - name: Install build
-        run: |
-          pip install build
+      - name: Install UV
+        uses: astral-sh/setup-uv@v7
       - name: Build project
         run: |
-          python3 -m build .
+          uv build
+      - name: Upload the build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  # Publishes python packages.
+  #
+  # Only runs on tag pushes.
+  publish_to_pypi:
+    name: Publish package to PyPi
+    needs:
+      - test
+      - build
+    if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sphinx-lua-ls
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
       - name: Publish to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -134,11 +167,11 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
-          prerelease: ${{ fromJSON(steps.changelog.outputs.is-pre-release) }}
-          draft: ${{ fromJSON(steps.changelog.outputs.is-unreleased) }}
+          prerelease: ${{ fromJSON(needs.build.outputs.is-pre-release) }}
+          draft: ${{ fromJSON(needs.build.outputs.is-unreleased) }}
           body: |
             ## Changelog
 
-            ${{ steps.changelog.outputs.text }}
+            ${{ needs.build.outputs.changelog-text }}
 
-            [See release on PyPi](${{ steps.metadata.outputs.link }})
+            [See release on PyPi](${{ needs.build.outputs.link }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
       - id: ruff-check
         name: ruff check
         language: system
-        entry: scripts/resolve_venv.sh ruff check --force-exclude
+        entry: uv run ruff check --force-exclude
         types_or: [python, pyi]
         require_serial: true
       - id: ruff-format
         name: ruff format
         language: system
-        entry: scripts/resolve_venv.sh ruff format --force-exclude
+        entry: uv run ruff format --force-exclude
         types_or: [python, pyi]
         require_serial: true
   - repo: https://github.com/taminomara/cl-keeper

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
       - id: ruff-check
         name: ruff check
         language: system
-        entry: uv run ruff check --force-exclude
+        entry: uv run --no-sync ruff check --force-exclude
         types_or: [python, pyi]
         require_serial: true
       - id: ruff-format
         name: ruff format
         language: system
-        entry: uv run ruff format --force-exclude
+        entry: uv run --no-sync ruff format --force-exclude
         types_or: [python, pyi]
         require_serial: true
   - repo: https://github.com/taminomara/cl-keeper

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,17 +13,17 @@ repos:
         entry: scripts/resolve_venv.sh ruff format --force-exclude
         types_or: [python, pyi]
         require_serial: true
+  - repo: https://github.com/taminomara/cl-keeper
+    rev: v1.0.0
+    hooks:
       - id: clk
-        name: changelog keeper
-        language: system
-        entry: scripts/resolve_venv.sh clk pre-commit-check
-        require_serial: true
-        types_or: [toml, yaml, markdown]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
+        exclude: "^(test/roots/.*|mre-sphinx-lua/.*)$"
       - id: end-of-file-fixer
+        exclude: "^(test/roots/.*|mre-sphinx-lua/.*)$"
       - id: fix-byte-order-marker
       - id: mixed-line-ending
         args: [--fix=lf]
@@ -33,6 +33,7 @@ repos:
       - id: check-json
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
+      - id: check-executables-have-shebangs
       - id: check-symlinks
       - id: destroyed-symlinks
       - id: check-vcs-permalinks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ We use [`uv`] and [`poe`] to run tasks, but it is possible to use pure pip as we
 
 ### Using pip
 
-1. Create a virtual environment with python `3.12` or newer.
+1. Create a virtual environment with python `3.13` or newer
+   (some of dev tools don't work with older pythons).
 
 2. Make sure your pip is up to date:
 
@@ -61,10 +62,10 @@ We use [`uv`] and [`poe`] to run tasks, but it is possible to use pure pip as we
    uv tool install poethepoet
    ```
 
-5. If you're not on linux, install [EmmyLua Doc Cli].
+4. If you're not on linux, install [EmmyLua Doc Cli].
 
 
-## Run tests
+## Run commands
 
 We use `poe` for most of the tasks:
 
@@ -83,11 +84,11 @@ poe --help
 
 ## Build docs
 
-Just run `sphinx` as usual, nothing special is required:
+To build docs, just use `poe`:
 
 ```shell
-cd docs/
-make html
+poe doc  # Build HTML.
+poe doc-watch  # Run sphinx-autobuild.
 ```
 
 Sphinx-LuaLs will download the latest version of Lua Language Server for you.
@@ -95,7 +96,7 @@ Sphinx-LuaLs will download the latest version of Lua Language Server for you.
 
 ## Release
 
-1. Make sure that "Unreleased" section in `changelog.md` is up to date.
+1. Make sure that "Unreleased" section in `CHANGELOG.md` is up to date.
 
 2. Run `poe release major|minor|patch` to bump version in changelog
    and create a release tag.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,18 +3,22 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -j auto -n
+SPHINXOPTS    ?= -j 12 -n
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+DOCTREEDIR    = build/doctrees
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" -d "$(DOCTREEDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help watch Makefile
+
+watch:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)"/html -d "$(DOCTREEDIR)" --watch ../sphinx_lua_ls $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" -d "$(DOCTREEDIR)" $(SPHINXOPTS) $(O)

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -1,31 +1,60 @@
 [executor]
 type = "uv"
+no-group = ["dev"]
 
 [tasks.lint]
 help = "Run pre-commit linters"
 cmd = "prek run --all-files"
+executor = { group = "lint" }
 
 [tasks.test]
 help = "Run tests"
-cmd = "tox -e 3.14"
+cmd = "tox -e 3.14,coverage-combine --"
+executor = { group = "ci" }
 
 [tasks.test-all]
 help = "Run tests for all pythons"
 cmd = "tox p --"
+executor = { group = "ci" }
 
-[tasks.doc]
-help = "Build HTML docs"
-cmd = "sphinx-build -b html docs/source docs/build/html -d docs/build/doctrees -j 12 -n"
+[tasks.cov-clear]
+help = "Erase coverage data (use this if you stop tests mid-flight)"
+cmd = "coverage erase"
+executor = { group = "test" }
 
-[tasks.doc-watch]
-help = "Start documentation server and rebuild HTML docs on every change"
-cmd = "sphinx-autobuild docs/source docs/build/html -d docs/build/doctrees --watch . -j 12 -n"
+[tasks._cov-html]
+cmd = "coverage html -d htmlcov"
+executor = { group = "test" }
 
-[tasks.release]
-help = "Bump version, create release commit and tag"
-cmd = "clk bump --commit"
-use_exec = true
+[tasks._cov-html-serve]
+cmd = "python -m http.server -b localhost 8081"
+cwd = "htmlcov"
+
+[tasks.test-cov]
+help = "Run tests with coverage and serve HTML report on localhost:8081"
+sequence = ["test", "_cov-html", "_cov-html-serve"]
+
+[tasks.test-cov-all]
+help = "Run tests for all pythons with coverage and serve HTML report on localhost:8081"
+sequence = ["test-all", "_cov-html", "_cov-html-serve"]
 
 [tasks.ci]
 help = "For CI job"
 cmd = "tox --colored yes p --skip-env lint --"
+executor = { group = "ci" }
+
+[tasks.doc]
+help = "Build HTML docs"
+cmd = "sphinx-build -b html docs/source docs/build/html -d docs/build/doctrees -j 12 -n"
+executor = { group = "doc" }
+
+[tasks.doc-watch]
+help = "Start documentation server and rebuild HTML docs on every change"
+cmd = "sphinx-autobuild docs/source docs/build/html -d docs/build/doctrees --watch . -j 12 -n"
+executor = { group = "doc" }
+
+[tasks.release]
+help = "Bump version, create release commit and tag"
+cmd = "uvx --from cl-keeper clk bump --commit"
+use_exec = true
+executor = { type = "simple" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "Framework :: Sphinx",
     "Framework :: Sphinx :: Domain",
@@ -25,32 +26,35 @@ dependencies = ["sphinx>=8.0,<10.0", "PyGithub>=1.59,<3.0", "requests~=2.31"]
 
 [dependency-groups]
 dev = [
-    "pytest-cov==7.1.0",
-    { include-group = "test" },
-    { include-group = "lint" },
+    { include-group = "ci" },
     { include-group = "doc" },
+    { include-group = "lint" },
+    { include-group = "test" },
+]
+test = [
+    "beautifulsoup4==4.14.3",
+    "myst-parser==5.0.0",
+    "pyright==1.1.409",
+    "pytest-cov==7.0.0",
+    "pytest-regressions==2.10.0",
+    "pytest==9.0.3",
+    "sybil==10.0.1",
+]
+doc = [
+    "furo==2025.12.19",
+    "myst-parser==5.0.0",
+    "sphinx-autobuild==2025.8.25",
+    "sphinx_design==0.7.0",
+    "sybil==10.0.1",
 ]
 lint = [
-    "cl-keeper==1.0.0",
     "prek==0.3.9",
     "ruff==0.15.12",
 ]
-test = [
-    "pyright==1.1.409",
-    "pytest==9.0.3",
-    "sybil==10.0.1",
-    "pytest-regressions==2.10.0",
-    "beautifulsoup4==4.14.3",
-    "myst-parser==5.0.0",
+ci = [
+    "pytest-cov==7.0.0",
     "tox==4.34.1",
     "tox-uv==1.29.0",
-]
-doc = [
-    "sybil==10.0.1",
-    "furo==2025.12.19",
-    "sphinx_design==0.7.0",
-    "myst-parser==5.0.0",
-    "sphinx-autobuild==2025.8.25",
 ]
 
 [project.urls]
@@ -65,22 +69,19 @@ requires = ["setuptools>=60", "setuptools_scm[toml]>=8", "wheel>=0.40"]
 [tool.setuptools_scm]
 write_to = "sphinx_lua_ls/_version.py"
 
-[tool.pytest.ini_options]
-minversion = "7.0"
-addopts = ["--strict-markers", "-p no:doctest"]
-testpaths = ["test", "sphinx_lua_ls", "docs"]
-
 [tool.pyright]
 include = ["sphinx_lua_ls"]
-exclude = ["**/__pycache__"]
+exclude = [
+    "**/__pycache__",
+    "sphinx_lua_ls/_version.py",
+    "examples/docs/*",
+    "test/roots/*",
+    "mre-sphinx-lua/*",
+]
 typeCheckingMode = "strict"
-pythonVersion = "3.12"
+pythonVersion = "3.14"
 pythonPlatform = "All"
 
-# deprecateTypingAliases = true
-reportUnnecessaryTypeIgnoreComment = "warning"
-reportUnusedFunction = "none"
-reportPrivateUsage = "none"
 reportMissingParameterType = "none"
 reportUnknownParameterType = "none"
 reportUnknownVariableType = "none"
@@ -88,11 +89,16 @@ reportUnknownMemberType = "none"
 reportUnknownArgumentType = "none"
 reportUnknownLambdaType = "none"
 reportUnnecessaryIsInstance = "none"
+reportUnnecessaryTypeIgnoreComment = "warning"
+reportPrivateUsage = "none"
+reportUnusedFunction = "none"
 reportConstantRedefinition = "none"
 reportRedeclaration = "none"
+reportDeprecated = "none"
+deprecateTypingAliases = true
 
 [tool.ruff]
-exclude = ["examples/docs/*", "test/roots/*"]
+exclude = ["examples/docs/*", "test/roots/*", "mre-sphinx-lua/*"]
 target-version = "py312"
 
 [tool.ruff.lint]
@@ -131,3 +137,6 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.format]
 docstring-code-format = true
+
+[tool.uv]
+default-groups = ["dev"]

--- a/pytest.toml
+++ b/pytest.toml
@@ -1,0 +1,4 @@
+[pytest]
+minversion = "9.0"
+addopts = ["--strict-markers", "-p no:doctest"]
+testpaths = ["test", "sphinx_lua_ls", "docs"]

--- a/scripts/resolve_venv.sh
+++ b/scripts/resolve_venv.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-if [[ -z $VIRTUAL_ENV && -f .venv/bin/activate ]]; then
-    source .venv/bin/activate
-fi
-
-$@

--- a/test/test_regression/autodoc-emmylua-object_types.html
+++ b/test/test_regression/autodoc-emmylua-object_types.html
@@ -966,14 +966,14 @@
      unknown
     </span>
    </code>
-   <span class="n">
-    <span class="pre">
-     ...
-    </span>
-   </span>
    <span class="p">
     <span class="pre">
      )
+    </span>
+   </span>
+   <span class="n">
+    <span class="pre">
+     ...
     </span>
    </span>
    <br/>

--- a/tox.toml
+++ b/tox.toml
@@ -5,6 +5,8 @@ env_list = [
     "3.12",
     "type",
     "lint",
+    "coverage-clean",
+    "coverage-combine",
 ]
 depends = []
 
@@ -19,16 +21,21 @@ commands = [
         "--no-sync",
         "pytest",
         "--color=yes",
+        "--cov",
+        "--cov-append",
         { replace = "posargs", default = [
         ], extend = true },
     ],
 ]
 pass_env = ["PYTEST*", "COVERAGE*", "LUA_LS_CACHE_PATH"]
+depends = ["coverage-clean"]
 package = "uv"
+set_env = { COVERAGE_FILE = "{env:COVERAGE_FILE:.coverage}.{envname}" }
 
 [env.type]
 description = "Run type check"
 dependency_groups = ["test"]
+skip_install = true
 commands = [["pyright"]]
 base_python = ["3.14"]
 
@@ -38,3 +45,19 @@ dependency_groups = ["lint"]
 skip_install = true
 commands = [["prek", "run", "--all-files", "--color=always"]]
 depends = []
+
+[env.coverage-clean]
+description = "Delete coverage data"
+dependency_groups = ["test"]
+skip_install = true
+commands = [["coverage", "erase"]]
+depends = []
+set_env = { COVERAGE_FILE = "{env:COVERAGE_FILE:.coverage}" }
+
+[env.coverage-combine]
+description = "Combine coverage data"
+dependency_groups = ["test"]
+skip_install = true
+commands = [["coverage", "combine"]]
+depends = ["3.14", "3.13", "3.12"]
+set_env = { COVERAGE_FILE = "{env:COVERAGE_FILE:.coverage}" }

--- a/tox.toml
+++ b/tox.toml
@@ -35,7 +35,6 @@ set_env = { COVERAGE_FILE = "{env:COVERAGE_FILE:.coverage}.{envname}" }
 [env.type]
 description = "Run type check"
 dependency_groups = ["test"]
-skip_install = true
 commands = [["pyright"]]
 base_python = ["3.14"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -230,27 +230,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cl-keeper"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "giturlparse" },
-    { name = "markdown-it-py" },
-    { name = "mdformat" },
-    { name = "mdformat-footnote" },
-    { name = "mdformat-gfm" },
-    { name = "mdformat-gfm-alerts" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "semver" },
-    { name = "yuio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/93/8e/f989a54f178d9a8575b610fdc4964a768cd7f14bc651e8167d157ead6349/cl_keeper-1.0.0.tar.gz", hash = "sha256:7f98151b15ccd05fdc9a30565562476605625dd66f506969f23b4869c7de9557", size = 115367, upload-time = "2026-03-11T17:59:58.884Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/20/767816208a164b5279cd593d599699b99096af7b32fece033d2bd9eac824/cl_keeper-1.0.0-py3-none-any.whl", hash = "sha256:6034030e6ffb0f246bd27fd4ccf07cb0d517491f7865eefc25589f522887e590", size = 42208, upload-time = "2026-03-11T17:59:57.792Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -452,15 +431,6 @@ wheels = [
 ]
 
 [[package]]
-name = "giturlparse"
-version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/1c/21a28489887463d1aed96257d233e98de2de2e912c1ff66067be43a0161e/giturlparse-0.13.0.tar.gz", hash = "sha256:f624251a2129595da32b282533802eb8db4a822f9ec64bb6c38bdf14ac1ff0e1", size = 15297, upload-time = "2025-10-22T08:36:47.587Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/fc/4cd75a11cbb59c3f171c07eb3ce96c69f457094a76f4249cac455e5b30cd/giturlparse-0.13.0-py2.py3-none-any.whl", hash = "sha256:a916bf43d50e6ab6aa0c6e21477be9065583ebcddd002f578162f7ad5224b9ba", size = 16007, upload-time = "2025-10-22T08:36:46.4Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -584,59 +554,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mdformat"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
-]
-
-[[package]]
-name = "mdformat-footnote"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdformat" },
-    { name = "mdit-py-plugins" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/27/25/08e1feac080165330278f31f605f28a963ef51864aee8306dd2039b55a61/mdformat_footnote-0.1.2.tar.gz", hash = "sha256:d8e6a7fece0f902f0c7dfbd009c093182b9b523527ae48f57f57506d79ccb4ec", size = 3358, upload-time = "2025-10-19T09:36:34.381Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/47/07544df46d55284cc1862acd49dc30f984e4e5cb1630becbf216692f30b6/mdformat_footnote-0.1.2-py3-none-any.whl", hash = "sha256:fe23888fc8ddb68c080bae9787a65bb1e51253f5de2bea2633feffdb095e59cd", size = 4139, upload-time = "2025-10-19T09:36:33.362Z" },
-]
-
-[[package]]
-name = "mdformat-gfm"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "mdformat" },
-    { name = "mdit-py-plugins" },
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
-]
-
-[[package]]
-name = "mdformat-gfm-alerts"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdformat" },
-    { name = "mdit-py-plugins" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/33/70619cf9e2b9e35857ebcf7e947e8f5370df2ff2a4ab666895783f8fab6c/mdformat_gfm_alerts-2.0.0.tar.gz", hash = "sha256:eb2b3189ad44ae28a6b6b714609dd3a30d6e3b898f02b1e6473d7b08df8bb3c0", size = 9687, upload-time = "2025-06-05T20:49:46.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/ea/22e093bb2ef3e25dc3ccc9d8392c14b069a007ae394a12e058d9e1f51c00/mdformat_gfm_alerts-2.0.0-py3-none-any.whl", hash = "sha256:e003422cc003bc6e936d0797553f23201095a1d1e8602c5062296d223f2ae516", size = 6752, upload-time = "2025-06-05T20:49:45.539Z" },
-]
-
-[[package]]
 name = "mdit-py-plugins"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -712,26 +629,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.3.8"
+version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/ee/03e8180e3fda9de25b6480bd15cc2bde40d573868d50648b0e527b35562f/prek-0.3.8.tar.gz", hash = "sha256:434a214256516f187a3ab15f869d950243be66b94ad47987ee4281b69643a2d9", size = 400224, upload-time = "2026-03-23T08:23:35.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/ff/5b7a2a9c4fa3dd2ffc8b13a9ec22aa550deda5b39ab273f8e02863b12642/prek-0.3.9.tar.gz", hash = "sha256:f82b92d81f42f1f90a47f5fbbf492373e25ef1f790080215b2722dd6da66510e", size = 423801, upload-time = "2026-04-13T12:30:38.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/84/40d2ddf362d12c4cd4a25a8c89a862edf87cdfbf1422aa41aac8e315d409/prek-0.3.8-py3-none-linux_armv6l.whl", hash = "sha256:6fb646ada60658fa6dd7771b2e0fb097f005151be222f869dada3eb26d79ed33", size = 5226646, upload-time = "2026-03-23T08:23:18.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/52/7308a033fa43b7e8e188797bd2b3b017c0f0adda70fa7af575b1f43ea888/prek-0.3.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3d7fdadb15efc19c09953c7a33cf2061a70f367d1e1957358d3ad5cc49d0616", size = 5620104, upload-time = "2026-03-23T08:23:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b1/f106ac000a91511a9cd80169868daf2f5b693480ef5232cec5517a38a512/prek-0.3.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72728c3295e79ca443f8c1ec037d2a5b914ec73a358f69cf1bc1964511876bf8", size = 5199867, upload-time = "2026-03-23T08:23:38.066Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e9/970713f4b019f69de9844e1bab37b8ddb67558e410916f4eb5869a696165/prek-0.3.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:48efc28f2f53b5b8087efca9daaed91572d62df97d5f24a1c7a087fecb5017de", size = 5441801, upload-time = "2026-03-23T08:23:32.617Z" },
-    { url = "https://files.pythonhosted.org/packages/12/a4/7ef44032b181753e19452ec3b09abb3a32607cf6b0a0508f0604becaaf2b/prek-0.3.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6ca9d63bacbc448a5c18e955c78d3ac5176c3a17c3baacdd949b1a623e08a36", size = 5155107, upload-time = "2026-03-23T08:23:31.021Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/77/4d9c8985dbba84149760785dfe07093ea1e29d710257dfb7c89615e2234c/prek-0.3.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1000f7029696b4fe712fb1fefd4c55b9c4de72b65509c8e50296370a06f9dc3f", size = 5566541, upload-time = "2026-03-23T08:23:45.694Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1a/81e6769ac1f7f8346d09ce2ab0b47cf06466acd9ff72e87e5d1f0d98cd32/prek-0.3.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ff0bed0e2c1286522987d982168a86cbbd0d069d840506a46c9fda983515517", size = 6552991, upload-time = "2026-03-23T08:23:21.958Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/fa/ce2df0dd2dc75a9437a52463239d0782998943d7b04e191fb89b83016c34/prek-0.3.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fb087ac0ffda3ac65bbbae9a38326a7fd27ee007bb4a94323ce1eb539d8bbec", size = 5832972, upload-time = "2026-03-23T08:23:20.258Z" },
-    { url = "https://files.pythonhosted.org/packages/18/6b/9d4269df9073216d296244595a21c253b6475dfc9076c0bd2906be7a436c/prek-0.3.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2e1e5e206ff7b31bd079cce525daddc96cd6bc544d20dc128921ad92f7a4c85d", size = 5448371, upload-time = "2026-03-23T08:23:41.835Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1d/1e4d8a78abefa5b9d086e5a9f1638a74b5e540eec8a648d9946707701f29/prek-0.3.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dcea3fe23832a4481bccb7c45f55650cb233be7c805602e788bb7dba60f2d861", size = 5270546, upload-time = "2026-03-23T08:23:24.231Z" },
-    { url = "https://files.pythonhosted.org/packages/77/07/34f36551a6319ae36e272bea63a42f59d41d2d47ab0d5fb00eb7b4e88e87/prek-0.3.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:4d25e647e9682f6818ab5c31e7a4b842993c14782a6ffcd128d22b784e0d677f", size = 5124032, upload-time = "2026-03-23T08:23:26.368Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/01/6d544009bb655e709993411796af77339f439526db4f3b3509c583ad8eb9/prek-0.3.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:de528b82935e33074815acff3c7c86026754d1212136295bc88fe9c43b4231d5", size = 5432245, upload-time = "2026-03-23T08:23:47.877Z" },
-    { url = "https://files.pythonhosted.org/packages/54/96/1237ee269e9bfa283ffadbcba1f401f48a47aed2b2563eb1002740d6079d/prek-0.3.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6d660f1c25a126e6d9f682fe61449441226514f412a4469f5d71f8f8cad56db2", size = 5950550, upload-time = "2026-03-23T08:23:43.8Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6b/a574411459049bc691047c9912f375deda10c44a707b6ce98df2b658f0b3/prek-0.3.8-py3-none-win32.whl", hash = "sha256:b0c291c577615d9f8450421dff0b32bfd77a6b0d223ee4115a1f820cb636fdf1", size = 4949501, upload-time = "2026-03-23T08:23:16.338Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b4/46b59fe49f635acd9f6530778ce577f9d8b49452835726a5311ffc902c67/prek-0.3.8-py3-none-win_amd64.whl", hash = "sha256:bc147fdbdd4ec33fc7a987b893ecb69b1413ac100d95c9889a70f3fd58c73d06", size = 5346551, upload-time = "2026-03-23T08:23:34.501Z" },
-    { url = "https://files.pythonhosted.org/packages/53/05/9cca1708bb8c65264124eb4b04251e0f65ce5bfc707080bb6b492d5a0df7/prek-0.3.8-py3-none-win_arm64.whl", hash = "sha256:a2614647aeafa817a5802ccb9561e92eedc20dcf840639a1b00826e2c2442515", size = 5190872, upload-time = "2026-03-23T08:23:29.463Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/08/c11a6b7834b461223763b6b1552f32c9199393685d52d555de621e900ee7/prek-0.3.9-py3-none-linux_armv6l.whl", hash = "sha256:3ed793d51bfaa27bddb64d525d7acb77a7c8644f549412d82252e3eb0b88aad8", size = 5337784, upload-time = "2026-04-13T12:30:46.044Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d9/974b02832a645c6411069c713e3191ce807f9962006da108e4727efd2fa1/prek-0.3.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:399c58400c0bd0b82a93a3c09dc1bfd88d8d0cfb242d414d2ed247187b06ead1", size = 5713864, upload-time = "2026-04-13T12:30:27.007Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e1/4ed14bef15eb30039a75177b0807ac007095a5a110284706ccf900a8d512/prek-0.3.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ea1ffb124e92f081b8e2ca5b5a623a733efb3be0c5b1f4b7ffe2ee17d1f20c", size = 5290437, upload-time = "2026-04-13T12:30:30.658Z" },
+    { url = "https://files.pythonhosted.org/packages/67/80/d5c3015e9da161dede566bfeef41f098f92470613157daa4f7377ab08d58/prek-0.3.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:aaf639f95b7301639298311d8d44aad0d0b4864e9736083ad3c71ce9765d37ab", size = 5536208, upload-time = "2026-04-13T12:30:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/8cdc5eb1018437d7828740defd322e7a96459c02fc8961160c4120325313/prek-0.3.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff104863b187fa443ea8451ca55d51e2c6e94f99f00d88784b5c3c4c623f1ebe", size = 5251785, upload-time = "2026-04-13T12:30:39.78Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e2/a5fc35a0fd3167224a000ca1b6235ecbdea0ac77e24af5979a75b0e6b5a4/prek-0.3.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:039ecaf87c63a3e67cca645ebd5bc5eb6aafa6c9d929e9a27b2921e7849d7ef9", size = 5668548, upload-time = "2026-04-13T12:30:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e8/a189ee79f401c259f66f8af587f899d4d5bfb04e0ca371bfd01e49871007/prek-0.3.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3bde2a3d045705095983c7f78ba04f72a7565fe1c2b4e85f5628502a254754ff", size = 6660927, upload-time = "2026-04-13T12:30:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28a0960a21543563e2c8e19aaad176cc8423a87aac3c914d0f313030d7a9244a", size = 5932244, upload-time = "2026-04-13T12:30:49.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/e88d4361f59be7adeeb3a8a3819d69d286d86fe6f7606840af6734362675/prek-0.3.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0dfb5d5171d7523271909246ee306b4dc3d5b63752e7dd7c7e8a8908fc9490d1", size = 5542139, upload-time = "2026-04-13T12:30:41.266Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1f/204837115087bb8d063bda754a7fe975428c5d5b6548c30dd749f8ab85d4/prek-0.3.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82b791bd36c1430c84d3ae7220a85152babc7eaf00f70adcb961bd594e756ba3", size = 5392519, upload-time = "2026-04-13T12:30:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/00/de57b5795e670b6d38e7eda6d9ac6fd6d757ca22f725e5054b042104cd53/prek-0.3.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:6eac6d2f736b041118f053a1487abed468a70dd85a8688eaf87bb42d3dcecf20", size = 5222780, upload-time = "2026-04-13T12:30:36.576Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/14/0bc055c305d92980b151f2ec00c14d28fe94c6d51180ca07fded28771cbf/prek-0.3.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:5517e46e761367a3759b3168eabc120840ffbca9dfbc53187167298a98f87dc4", size = 5524310, upload-time = "2026-04-13T12:30:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d1/eebc2b69be0de36cd84adbe0a0710f4deb468a90e30525be027d6db02d54/prek-0.3.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:92024778cf78683ca32687bb249ab6a7d5c33887b5ee1d1a9f6d0c14228f4cf3", size = 6043751, upload-time = "2026-04-13T12:30:29.101Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cb/be98c04e702cbc0b0328cd745ff4634ace69ad5a84461bde36f88a7be873/prek-0.3.9-py3-none-win32.whl", hash = "sha256:7f89c55e5f480f5d073769e319924ad69d4bf9f98c5cb46a83082e26e634c958", size = 5045940, upload-time = "2026-04-13T12:30:42.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b6/b51771d69f6282e34edeb73f23d956da34f2cabbb5ba16ba175cc0a056f9/prek-0.3.9-py3-none-win_amd64.whl", hash = "sha256:7722f3372eaa83b147e70a43cb7b9fe2128c13d0c78d8a1cdbf2a8ec2ee071eb", size = 5435204, upload-time = "2026-04-13T12:30:51.482Z" },
+    { url = "https://files.pythonhosted.org/packages/30/8a/f8a87c15b095460eccd67c8d89a086b7a37aac8d363f89544b8ce6ec653d/prek-0.3.9-py3-none-win_arm64.whl", hash = "sha256:0bced6278d6cc8a4b46048979e36bc9da034611dc8facd77ab123177b833a929", size = 5279552, upload-time = "2026-04-13T12:30:53.011Z" },
 ]
 
 [[package]]
@@ -831,15 +748,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -860,16 +777,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.1.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]
@@ -983,36 +900,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.8"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
-    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
-    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
-    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
-    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
-    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
-    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
-]
-
-[[package]]
-name = "semver"
-version = "3.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -1112,9 +1020,13 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+ci = [
+    { name = "pytest-cov" },
+    { name = "tox" },
+    { name = "tox-uv" },
+]
 dev = [
     { name = "beautifulsoup4" },
-    { name = "cl-keeper" },
     { name = "furo" },
     { name = "myst-parser" },
     { name = "prek" },
@@ -1137,7 +1049,6 @@ doc = [
     { name = "sybil" },
 ]
 lint = [
-    { name = "cl-keeper" },
     { name = "prek" },
     { name = "ruff" },
 ]
@@ -1146,10 +1057,9 @@ test = [
     { name = "myst-parser" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pytest-regressions" },
     { name = "sybil" },
-    { name = "tox" },
-    { name = "tox-uv" },
 ]
 
 [package.metadata]
@@ -1160,17 +1070,21 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+ci = [
+    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "tox", specifier = "==4.34.1" },
+    { name = "tox-uv", specifier = "==1.29.0" },
+]
 dev = [
     { name = "beautifulsoup4", specifier = "==4.14.3" },
-    { name = "cl-keeper", specifier = "==1.0.0" },
     { name = "furo", specifier = "==2025.12.19" },
     { name = "myst-parser", specifier = "==5.0.0" },
-    { name = "prek", specifier = "==0.3.8" },
-    { name = "pyright", specifier = "==1.1.408" },
+    { name = "prek", specifier = "==0.3.9" },
+    { name = "pyright", specifier = "==1.1.409" },
     { name = "pytest", specifier = "==9.0.3" },
-    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-regressions", specifier = "==2.10.0" },
-    { name = "ruff", specifier = "==0.15.8" },
+    { name = "ruff", specifier = "==0.15.12" },
     { name = "sphinx-autobuild", specifier = "==2025.8.25" },
     { name = "sphinx-design", specifier = "==0.7.0" },
     { name = "sybil", specifier = "==10.0.1" },
@@ -1185,19 +1099,17 @@ doc = [
     { name = "sybil", specifier = "==10.0.1" },
 ]
 lint = [
-    { name = "cl-keeper", specifier = "==1.0.0" },
-    { name = "prek", specifier = "==0.3.8" },
-    { name = "ruff", specifier = "==0.15.8" },
+    { name = "prek", specifier = "==0.3.9" },
+    { name = "ruff", specifier = "==0.15.12" },
 ]
 test = [
     { name = "beautifulsoup4", specifier = "==4.14.3" },
     { name = "myst-parser", specifier = "==5.0.0" },
-    { name = "pyright", specifier = "==1.1.408" },
+    { name = "pyright", specifier = "==1.1.409" },
     { name = "pytest", specifier = "==9.0.3" },
+    { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-regressions", specifier = "==2.10.0" },
     { name = "sybil", specifier = "==10.0.1" },
-    { name = "tox", specifier = "==4.34.1" },
-    { name = "tox-uv", specifier = "==1.29.0" },
 ]
 
 [[package]]
@@ -1453,15 +1365,6 @@ wheels = [
 ]
 
 [[package]]
-name = "wcwidth"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
-]
-
-[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1504,16 +1407,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "yuio"
-version = "2.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/d7/d34fed05533f0f90c034c1a2461c217b28683354311474e1d246cc3a4308/yuio-2.5.1.tar.gz", hash = "sha256:a51bb0ffde93a8d9fff9a5d101a0c1073f2760d6564c13e9e8c0a1637984f540", size = 694109, upload-time = "2026-03-25T10:05:27.807Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/f5/2025124bea84d60e8bd697ac6a600428a9907f29d9fe540f614948557ed7/yuio-2.5.1-py3-none-any.whl", hash = "sha256:70e64984f6701b8db3f4bbe9db4ab8a053d8d97c950c9be467634907eafdfd43", size = 368634, upload-time = "2026-03-25T10:05:26.206Z" },
 ]


### PR DESCRIPTION
## Summary

Align the dev harness with [`taminomara/yuio`](https://github.com/taminomara/yuio):

- **uv** replaces pip; `uv.lock` committed
- **ruff** replaces black + isort (yuio's rule list)
- **pyright** type-check job
- **tox + tox-uv** multi-Python matrix in `tox.toml`; `[env.type]` keeps `package = "uv"` because pyright needs runtime deps to resolve
- Pytest config moved to `pytest.toml` (+ `.coveragerc.toml`)
- `poe_tasks.toml` with `lint`, `test`, `test-cov`, `ci`, `doc`, `doc-watch`
- **prek** replaces pre-commit; **cl-keeper** hook formats `CHANGELOG.md`
- CI release job split into `build` (no tokens, parses changelog) and `publish_to_pypi` (PyPI trusted publishing + GH release) for supply-chain hygiene
- `dependabot.yml` tracks python, github-actions, and pre-commit ecosystems
- `CHANGELOG.md` reformatted via `clk fix`
- `CONTRIBUTING.md` updated for the new workflow

## Notes

- PyPI trusted publishing config on the project side needs to be verified before the next tag push

## Test plan
- [ ] CI green on this branch
- [ ] PyPI trusted publishing configured for the `pypi` environment
- [ ] Local `poe ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)